### PR TITLE
feat : invoice number reservation

### DIFF
--- a/jeecg-module-system/jeecg-system-biz/src/main/java/org/jeecg/modules/business/controller/admin/CreditController.java
+++ b/jeecg-module-system/jeecg-system-biz/src/main/java/org/jeecg/modules/business/controller/admin/CreditController.java
@@ -145,7 +145,6 @@ public class CreditController extends JeecgController<Credit, ICreditService> {
 			log.error("User {}, tried to access /credit/edit but is not authorized.", loginUser.getUsername());
 			return Result.error(HttpStatus.SC_FORBIDDEN,"Access denied");
 		}
-		// we want the balance to update so we can use it later when we generate the invoice
 		log.info("editing credit");
 		Credit lastCredit = creditService.getLastCredit(credit.getClientId(), credit.getCurrencyId());
 		Credit creditToEdit = creditService.getById(credit.getId());

--- a/jeecg-module-system/jeecg-system-biz/src/main/java/org/jeecg/modules/business/controller/admin/InvoiceNumberReservationController.java
+++ b/jeecg-module-system/jeecg-system-biz/src/main/java/org/jeecg/modules/business/controller/admin/InvoiceNumberReservationController.java
@@ -1,0 +1,163 @@
+package org.jeecg.modules.business.controller.admin;
+
+import java.util.Arrays;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.jeecg.common.api.vo.Result;
+import org.jeecg.common.system.query.QueryGenerator;
+import org.jeecg.modules.business.entity.InvoiceNumberReservation;
+import org.jeecg.modules.business.service.IInvoiceNumberReservationService;
+
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import lombok.extern.slf4j.Slf4j;
+
+import org.jeecg.common.system.base.controller.JeecgController;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.ModelAndView;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import org.jeecg.common.aspect.annotation.AutoLog;
+import org.apache.shiro.authz.annotation.RequiresPermissions;
+
+ /**
+ * @Description: invoice number reservation
+ * @Author: jeecg-boot
+ * @Date:   2025-03-28
+ * @Version: V1.0
+ */
+@Api(tags="invoice number reservation")
+@RestController
+@RequestMapping("/business/invoiceNumberReservation")
+@Slf4j
+public class InvoiceNumberReservationController extends JeecgController<InvoiceNumberReservation, IInvoiceNumberReservationService> {
+	@Autowired
+	private IInvoiceNumberReservationService invoiceNumberReservationService;
+	
+	/**
+	 * 分页列表查询
+	 *
+	 * @param invoiceNumberReservation
+	 * @param pageNo
+	 * @param pageSize
+	 * @param req
+	 * @return
+	 */
+	//@AutoLog(value = "invoice number reservation-分页列表查询")
+	@ApiOperation(value="invoice number reservation-分页列表查询", notes="invoice number reservation-分页列表查询")
+	@GetMapping(value = "/list")
+	public Result<IPage<InvoiceNumberReservation>> queryPageList(InvoiceNumberReservation invoiceNumberReservation,
+								   @RequestParam(name="pageNo", defaultValue="1") Integer pageNo,
+								   @RequestParam(name="pageSize", defaultValue="10") Integer pageSize,
+								   HttpServletRequest req) {
+		QueryWrapper<InvoiceNumberReservation> queryWrapper = QueryGenerator.initQueryWrapper(invoiceNumberReservation, req.getParameterMap());
+		Page<InvoiceNumberReservation> page = new Page<InvoiceNumberReservation>(pageNo, pageSize);
+		IPage<InvoiceNumberReservation> pageList = invoiceNumberReservationService.page(page, queryWrapper);
+		return Result.OK(pageList);
+	}
+	
+	/**
+	 *   添加
+	 *
+	 * @param invoiceNumberReservation
+	 * @return
+	 */
+	@AutoLog(value = "invoice number reservation-添加")
+	@ApiOperation(value="invoice number reservation-添加", notes="invoice number reservation-添加")
+	@RequiresPermissions("business:invoice_number_reservation:add")
+	@PostMapping(value = "/add")
+	public Result<String> add(@RequestBody InvoiceNumberReservation invoiceNumberReservation) {
+		invoiceNumberReservationService.save(invoiceNumberReservation);
+		return Result.OK("添加成功！");
+	}
+	
+	/**
+	 *  编辑
+	 *
+	 * @param invoiceNumberReservation
+	 * @return
+	 */
+	@AutoLog(value = "invoice number reservation-编辑")
+	@ApiOperation(value="invoice number reservation-编辑", notes="invoice number reservation-编辑")
+	@RequiresPermissions("business:invoice_number_reservation:edit")
+	@RequestMapping(value = "/edit", method = {RequestMethod.PUT,RequestMethod.POST})
+	public Result<String> edit(@RequestBody InvoiceNumberReservation invoiceNumberReservation) {
+		invoiceNumberReservationService.updateById(invoiceNumberReservation);
+		return Result.OK("编辑成功!");
+	}
+	
+	/**
+	 *   通过id删除
+	 *
+	 * @param id
+	 * @return
+	 */
+	@AutoLog(value = "invoice number reservation-通过id删除")
+	@ApiOperation(value="invoice number reservation-通过id删除", notes="invoice number reservation-通过id删除")
+	@RequiresPermissions("business:invoice_number_reservation:delete")
+	@DeleteMapping(value = "/delete")
+	public Result<String> delete(@RequestParam(name="id",required=true) String id) {
+		invoiceNumberReservationService.removeById(id);
+		return Result.OK("删除成功!");
+	}
+	
+	/**
+	 *  批量删除
+	 *
+	 * @param ids
+	 * @return
+	 */
+	@AutoLog(value = "invoice number reservation-批量删除")
+	@ApiOperation(value="invoice number reservation-批量删除", notes="invoice number reservation-批量删除")
+	@RequiresPermissions("business:invoice_number_reservation:deleteBatch")
+	@DeleteMapping(value = "/deleteBatch")
+	public Result<String> deleteBatch(@RequestParam(name="ids",required=true) String ids) {
+		this.invoiceNumberReservationService.removeByIds(Arrays.asList(ids.split(",")));
+		return Result.OK("批量删除成功!");
+	}
+	
+	/**
+	 * 通过id查询
+	 *
+	 * @param id
+	 * @return
+	 */
+	//@AutoLog(value = "invoice number reservation-通过id查询")
+	@ApiOperation(value="invoice number reservation-通过id查询", notes="invoice number reservation-通过id查询")
+	@GetMapping(value = "/queryById")
+	public Result<InvoiceNumberReservation> queryById(@RequestParam(name="id",required=true) String id) {
+		InvoiceNumberReservation invoiceNumberReservation = invoiceNumberReservationService.getById(id);
+		if(invoiceNumberReservation==null) {
+			return Result.error("未找到对应数据");
+		}
+		return Result.OK(invoiceNumberReservation);
+	}
+
+    /**
+    * 导出excel
+    *
+    * @param request
+    * @param invoiceNumberReservation
+    */
+    @RequiresPermissions("business:invoice_number_reservation:exportXls")
+    @RequestMapping(value = "/exportXls")
+    public ModelAndView exportXls(HttpServletRequest request, InvoiceNumberReservation invoiceNumberReservation) {
+        return super.exportXls(request, invoiceNumberReservation, InvoiceNumberReservation.class, "invoice number reservation");
+    }
+
+    /**
+      * 通过excel导入数据
+    *
+    * @param request
+    * @param response
+    * @return
+    */
+    @RequiresPermissions("business:invoice_number_reservation:importExcel")
+    @RequestMapping(value = "/importExcel", method = RequestMethod.POST)
+    public Result<?> importExcel(HttpServletRequest request, HttpServletResponse response) {
+        return super.importExcel(request, response, InvoiceNumberReservation.class);
+    }
+
+}

--- a/jeecg-module-system/jeecg-system-biz/src/main/java/org/jeecg/modules/business/domain/shippingInvoice/ShippingInvoiceFactory.java
+++ b/jeecg-module-system/jeecg-system-biz/src/main/java/org/jeecg/modules/business/domain/shippingInvoice/ShippingInvoiceFactory.java
@@ -35,6 +35,7 @@ import java.util.stream.Collectors;
 
 import static cn.hutool.core.date.DateTime.now;
 import static java.util.stream.Collectors.*;
+import static org.jeecg.modules.business.entity.Invoice.InvoiceType.*;
 
 @Slf4j
 @Component
@@ -74,6 +75,8 @@ public class ShippingInvoiceFactory {
     private ILogisticInsuranceService logisticInsuranceService;
     @Autowired
     private EmailService emailService;
+    @Autowired
+    private IInvoiceNumberReservationService invoiceNumberReservationService;
     @Autowired
     private Environment env;
 
@@ -237,7 +240,7 @@ public class ShippingInvoiceFactory {
         Map<String, BigDecimal> shopPackageMatFeeMap = new HashMap<>();
         shops.forEach(shop -> shopServiceFeeMap.put(shop.getId(), shop.getOrderServiceFee()));
         shops.forEach(shop -> shopPackageMatFeeMap.put(shop.getId(), shop.getPackagingMaterialFee()));
-        String invoiceCode = generateCompleteInvoiceCode();
+        String invoiceCode = invoiceNumberReservationService.getLatestInvoiceNumberByType(COMPLETE.getType());
         log.info("New invoice code: {}", invoiceCode);
         calculateFees(balance, logisticChannelMap, orderAndContent, channelPriceMap, countryList, skuRealWeights, skuServiceFees,
                 latestDeclaredValues, client, shopServiceFeeMap, shopPackageMatFeeMap, invoiceCode);
@@ -317,7 +320,7 @@ public class ShippingInvoiceFactory {
         Map<String, BigDecimal> shopPackageMatFeeMap = new HashMap<>();
         shops.forEach(shop -> shopServiceFeeMap.put(shop.getId(), shop.getOrderServiceFee()));
         shops.forEach(shop -> shopPackageMatFeeMap.put(shop.getId(), shop.getPackagingMaterialFee()));
-        String invoiceCode = generateCompleteInvoiceCode();
+        String invoiceCode = invoiceNumberReservationService.getLatestInvoiceNumberByType(COMPLETE.getType());
 
         log.info("New invoice code: {}", invoiceCode);
 
@@ -572,7 +575,7 @@ public class ShippingInvoiceFactory {
         Map<String, BigDecimal> shopPackageMatFeeMap = new HashMap<>();
         shops.forEach(shop -> shopServiceFeeMap.put(shop.getId(), shop.getOrderServiceFee()));
         shops.forEach(shop -> shopPackageMatFeeMap.put(shop.getId(), shop.getPackagingMaterialFee()));
-        String invoiceCode = generateInvoiceCode();
+        String invoiceCode = invoiceNumberReservationService.getLatestInvoiceNumberByType(SHIPPING.getType());
         log.info("New invoice code: {}", invoiceCode);
         Map<String, List<String>> errorMsg = calculateFees(null, logisticChannelMap, orderAndContent, channelPriceMap, countryList, skuRealWeights, skuServiceFees,
                 latestDeclaredValues, client, shopServiceFeeMap, shopPackageMatFeeMap, invoiceCode);
@@ -646,7 +649,7 @@ public class ShippingInvoiceFactory {
         Map<String, BigDecimal> shopPackageMatFeeMap = new HashMap<>();
         shops.forEach(shop -> shopServiceFeeMap.put(shop.getId(), shop.getOrderServiceFee()));
         shops.forEach(shop -> shopPackageMatFeeMap.put(shop.getId(), shop.getPackagingMaterialFee()));
-        String invoiceCode = generateInvoiceCode();
+        String invoiceCode = invoiceNumberReservationService.getLatestInvoiceNumberByType(SHIPPING.getType());
         log.info("New invoice code: {}", invoiceCode);
         Map<String, List<String>> ordersWithPB = calculateFees(balance, logisticChannelMap, orderAndContent, channelPriceMap, countryList, skuRealWeights, skuServiceFees,
                 latestDeclaredValues, client, shopServiceFeeMap, shopPackageMatFeeMap, invoiceCode);

--- a/jeecg-module-system/jeecg-system-biz/src/main/java/org/jeecg/modules/business/entity/InvoiceNumberReservation.java
+++ b/jeecg-module-system/jeecg-system-biz/src/main/java/org/jeecg/modules/business/entity/InvoiceNumberReservation.java
@@ -1,0 +1,67 @@
+package org.jeecg.modules.business.entity;
+
+import java.io.Serializable;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.jeecgframework.poi.excel.annotation.Excel;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.Accessors;
+
+/**
+ * @Description: invoice number reservation
+ * @Author: jeecg-boot
+ * @Date:   2025-03-28
+ * @Version: V1.0
+ */
+@Data
+@TableName("invoice_number_reservation")
+@Accessors(chain = true)
+@EqualsAndHashCode(callSuper = false)
+@ApiModel(value="invoice_number_reservation对象", description="invoice number reservation")
+public class InvoiceNumberReservation implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+	/**主键*/
+	@TableId(type = IdType.ASSIGN_ID)
+    @ApiModelProperty(value = "主键")
+    private java.lang.String id;
+	/**创建人*/
+    @ApiModelProperty(value = "创建人")
+    private java.lang.String createBy;
+	/**创建日期*/
+	@JsonFormat(timezone = "GMT+8",pattern = "yyyy-MM-dd HH:mm:ss")
+    @DateTimeFormat(pattern="yyyy-MM-dd HH:mm:ss")
+    @ApiModelProperty(value = "创建日期")
+    private java.util.Date createTime;
+	/**更新人*/
+    @ApiModelProperty(value = "更新人")
+    private java.lang.String updateBy;
+	/**更新日期*/
+	@JsonFormat(timezone = "GMT+8",pattern = "yyyy-MM-dd HH:mm:ss")
+    @DateTimeFormat(pattern="yyyy-MM-dd HH:mm:ss")
+    @ApiModelProperty(value = "更新日期")
+    private java.util.Date updateTime;
+	/**invoice type*/
+	@Excel(name = "invoice type", width = 15)
+    @ApiModelProperty(value = "invoice type")
+    private java.lang.Integer type;
+	/**invoice number*/
+	@Excel(name = "invoice number", width = 15)
+    @ApiModelProperty(value = "invoice number")
+    private java.lang.Integer number;
+	/**year*/
+	@Excel(name = "year", width = 15)
+    @ApiModelProperty(value = "year")
+    private java.lang.String year;
+	/**month*/
+	@Excel(name = "month", width = 15)
+    @ApiModelProperty(value = "month")
+    private java.lang.String month;
+}

--- a/jeecg-module-system/jeecg-system-biz/src/main/java/org/jeecg/modules/business/mapper/InvoiceNumberReservationMapper.java
+++ b/jeecg-module-system/jeecg-system-biz/src/main/java/org/jeecg/modules/business/mapper/InvoiceNumberReservationMapper.java
@@ -1,0 +1,16 @@
+package org.jeecg.modules.business.mapper;
+
+import org.jeecg.modules.business.entity.InvoiceNumberReservation;
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import org.springframework.stereotype.Repository;
+
+/**
+ * @Description: invoice number reservation
+ * @Author: jeecg-boot
+ * @Date:   2025-03-28
+ * @Version: V1.0
+ */
+@Repository
+public interface InvoiceNumberReservationMapper extends BaseMapper<InvoiceNumberReservation> {
+
+}

--- a/jeecg-module-system/jeecg-system-biz/src/main/java/org/jeecg/modules/business/mapper/ShippingInvoiceMapper.java
+++ b/jeecg-module-system/jeecg-system-biz/src/main/java/org/jeecg/modules/business/mapper/ShippingInvoiceMapper.java
@@ -33,4 +33,8 @@ public interface ShippingInvoiceMapper extends BaseMapper<ShippingInvoice> {
     Period getInvoicePeriod(@Param("shops") List<String> shopIdList);
 
     void cancelInvoice(@Param("id") String invoiceId);
+
+    String findLatestInvoiceNumber();
+
+    String findLatestCompleteInvoiceNumber();
 }

--- a/jeecg-module-system/jeecg-system-biz/src/main/java/org/jeecg/modules/business/mapper/xml/InvoiceNumberReservationMapper.xml
+++ b/jeecg-module-system/jeecg-system-biz/src/main/java/org/jeecg/modules/business/mapper/xml/InvoiceNumberReservationMapper.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.jeecg.modules.business.mapper.InvoiceNumberReservationMapper">
+
+</mapper>

--- a/jeecg-module-system/jeecg-system-biz/src/main/java/org/jeecg/modules/business/mapper/xml/ShippingInvoiceMapper.xml
+++ b/jeecg-module-system/jeecg-system-biz/src/main/java/org/jeecg/modules/business/mapper/xml/ShippingInvoiceMapper.xml
@@ -117,4 +117,20 @@
         SET status = 0
         WHERE id = #{id};
     </update>
+    <select id="findLatestInvoiceNumber" resultType="java.lang.String">
+        SELECT invoice_number
+        FROM shipping_invoice
+        WHERE invoice_number IS NOT NULL
+        AND invoice_number LIKE '2%%%-%%-2%%%'
+        ORDER BY invoice_number DESC
+        LIMIT 1
+    </select>
+    <select id="findLatestCompleteInvoiceNumber" resultType="java.lang.String">
+        SELECT invoice_number
+        FROM shipping_invoice
+        WHERE invoice_number IS NOT NULL
+        AND invoice_number LIKE '2%%%-%%-7%%%'
+        ORDER BY invoice_number DESC
+        LIMIT 1
+    </select>
 </mapper>

--- a/jeecg-module-system/jeecg-system-biz/src/main/java/org/jeecg/modules/business/service/IInvoiceNumberReservationService.java
+++ b/jeecg-module-system/jeecg-system-biz/src/main/java/org/jeecg/modules/business/service/IInvoiceNumberReservationService.java
@@ -1,0 +1,17 @@
+package org.jeecg.modules.business.service;
+
+import org.jeecg.modules.business.entity.InvoiceNumberReservation;
+import com.baomidou.mybatisplus.extension.service.IService;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * @Description: invoice number reservation
+ * @Author: jeecg-boot
+ * @Date:   2025-03-28
+ * @Version: V1.0
+ */
+public interface IInvoiceNumberReservationService extends IService<InvoiceNumberReservation> {
+
+    @Transactional
+    String getLatestInvoiceNumberByType(int invoiceType);
+}

--- a/jeecg-module-system/jeecg-system-biz/src/main/java/org/jeecg/modules/business/service/IShippingInvoiceService.java
+++ b/jeecg-module-system/jeecg-system-biz/src/main/java/org/jeecg/modules/business/service/IShippingInvoiceService.java
@@ -53,4 +53,8 @@ public interface IShippingInvoiceService extends IService<ShippingInvoice> {
     Period getInvoicePeriod(List<String> shopIdList);
 
     void cancelInvoice(String invoiceId);
+
+    String findLatestInvoiceNumber();
+
+    String findLatestCompleteInvoiceNumber();
 }

--- a/jeecg-module-system/jeecg-system-biz/src/main/java/org/jeecg/modules/business/service/impl/CreditServiceImpl.java
+++ b/jeecg-module-system/jeecg-system-biz/src/main/java/org/jeecg/modules/business/service/impl/CreditServiceImpl.java
@@ -4,7 +4,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.http.HttpStatus;
 import org.apache.shiro.SecurityUtils;
 import org.jeecg.common.system.vo.LoginUser;
-import org.jeecg.modules.business.domain.codeGeneration.CreditInvoiceCodeRule;
 import org.jeecg.modules.business.domain.credit.CreditInvoice;
 import org.jeecg.modules.business.domain.credit.CreditInvoiceFactory;
 import org.jeecg.modules.business.entity.Balance;
@@ -32,6 +31,8 @@ import java.nio.file.StandardCopyOption;
 import java.text.SimpleDateFormat;
 import java.util.List;
 
+import static org.jeecg.modules.business.entity.Invoice.InvoiceType.CREDIT;
+
 /**
  * @Description: credit
  * @Author: jeecg-boot
@@ -55,6 +56,8 @@ public class CreditServiceImpl extends ServiceImpl<CreditMapper, Credit> impleme
     private CreditInvoiceFactory factory;
     @Autowired
     private ICurrencyService currencyService;
+    @Autowired
+    private IInvoiceNumberReservationService invoiceNumberReservationService;
 
     @Override
     public Credit getLastCredit(String clientId,String currencyId) {
@@ -85,8 +88,7 @@ public class CreditServiceImpl extends ServiceImpl<CreditMapper, Credit> impleme
             res.setStatus(HttpStatus.SC_NOT_FOUND);
             return res;
         }
-        String lastInvoiceNumber = getLatestInvoiceNumber();
-        String invoiceNumber = new CreditInvoiceCodeRule().next(lastInvoiceNumber);
+        String invoiceNumber =  invoiceNumberReservationService.getLatestInvoiceNumberByType(CREDIT.getType());
         credit.setInvoiceNumber(invoiceNumber);
         save(credit);
         balanceService.updateBalance(credit.getClientId(), credit.getId(), credit.getAmount(), credit.getCurrencyId());

--- a/jeecg-module-system/jeecg-system-biz/src/main/java/org/jeecg/modules/business/service/impl/InvoiceNumberReservationServiceImpl.java
+++ b/jeecg-module-system/jeecg-system-biz/src/main/java/org/jeecg/modules/business/service/impl/InvoiceNumberReservationServiceImpl.java
@@ -1,0 +1,103 @@
+package org.jeecg.modules.business.service.impl;
+
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import lombok.extern.slf4j.Slf4j;
+import org.jeecg.modules.business.domain.codeGeneration.CompleteInvoiceCodeRule;
+import org.jeecg.modules.business.domain.codeGeneration.CreditInvoiceCodeRule;
+import org.jeecg.modules.business.domain.codeGeneration.PurchaseInvoiceCodeRule;
+import org.jeecg.modules.business.domain.codeGeneration.ShippingInvoiceCodeRule;
+import org.jeecg.modules.business.entity.InvoiceNumberReservation;
+import org.jeecg.modules.business.mapper.CreditMapper;
+import org.jeecg.modules.business.mapper.InvoiceNumberReservationMapper;
+import org.jeecg.modules.business.mapper.PurchaseOrderMapper;
+import org.jeecg.modules.business.service.IInvoiceNumberReservationService;
+import org.jeecg.modules.business.service.IPlatformOrderService;
+import org.jeecg.modules.business.entity.Invoice.InvoiceType;
+import org.jeecg.modules.business.service.IShippingInvoiceService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Calendar;
+
+/**
+ * @Description: invoice number reservation
+ * @Author: jeecg-boot
+ * @Date:   2025-03-28
+ * @Version: V1.0
+ */
+@Service
+@Slf4j
+public class InvoiceNumberReservationServiceImpl extends ServiceImpl<InvoiceNumberReservationMapper, InvoiceNumberReservation> implements IInvoiceNumberReservationService {
+    @Autowired
+    private CreditMapper creditMapper;
+    @Autowired
+    private IPlatformOrderService platformOrderService;
+    @Autowired
+    private PurchaseOrderMapper purchaseOrderMapper;
+    @Autowired
+    private IShippingInvoiceService shippingInvoiceService;
+
+    /**
+     * Generates a new invoice number based on the current date and the specified invoice type.
+     * This method will create a new invoice number reservation by committing the transaction regardless of the current transaction state of the caller.
+     * @param invoiceType 1: Purchase Invoice, 2: Shipping Invoice, 7: Complete Invoice, 8: Credit Invoice
+     * @return
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Override
+    public String getLatestInvoiceNumberByType(int invoiceType) {
+        String latestInvoiceCode, newInvoiceCode;
+        Calendar calendar = Calendar.getInstance();
+        int year = calendar.get(Calendar.YEAR);
+        int month = calendar.get(Calendar.MONTH) + 1;
+        String yearStr = String.valueOf(year);
+        String monthStr = String.format("%02d", month);
+        int newNumber;
+        InvoiceNumberReservation latestInvoiceNumberReservation = this.getOne(
+                new QueryWrapper<InvoiceNumberReservation>().eq("type", invoiceType));
+        if (latestInvoiceNumberReservation != null) {
+            if(latestInvoiceNumberReservation.getYear().equals(yearStr) && latestInvoiceNumberReservation.getMonth().equals(monthStr)) {
+                newNumber = latestInvoiceNumberReservation.getNumber() + 1;
+            } else {
+                newNumber = 1;
+            }
+            newInvoiceCode = yearStr + "-" + monthStr + "-" + invoiceType + String.format("%03d", newNumber);
+
+            latestInvoiceNumberReservation.setNumber(newNumber);
+            latestInvoiceNumberReservation.setYear(yearStr);
+            latestInvoiceNumberReservation.setMonth(monthStr);
+            update(latestInvoiceNumberReservation, new QueryWrapper<InvoiceNumberReservation>().eq("type", invoiceType));
+        } else {
+            if(invoiceType == InvoiceType.SHIPPING.getType()) {
+                latestInvoiceCode = shippingInvoiceService.findLatestInvoiceNumber();
+                newInvoiceCode = new ShippingInvoiceCodeRule().next(latestInvoiceCode);
+            } else if(invoiceType == InvoiceType.COMPLETE.getType()) {
+                latestInvoiceCode = shippingInvoiceService.findLatestCompleteInvoiceNumber();
+                newInvoiceCode = new CompleteInvoiceCodeRule().next(latestInvoiceCode);
+            } else if(invoiceType == InvoiceType.PURCHASE.getType()) {
+                latestInvoiceCode = purchaseOrderMapper.lastInvoiceNumber();
+                newInvoiceCode = new PurchaseInvoiceCodeRule().next(latestInvoiceCode);
+            } else if(invoiceType == InvoiceType.CREDIT.getType()) {
+                latestInvoiceCode = creditMapper.getLatestInvoiceNumber();
+                newInvoiceCode = new CreditInvoiceCodeRule().next(latestInvoiceCode);
+            }
+            else {
+                throw new IllegalArgumentException("Invalid invoice type: " + invoiceType);
+
+            }
+            newNumber = Integer.parseInt(newInvoiceCode.substring(newInvoiceCode.lastIndexOf("-") + 2));
+            InvoiceNumberReservation newNumberReservation = new InvoiceNumberReservation();
+            newNumberReservation.setNumber(newNumber);
+            newNumberReservation.setType(invoiceType);
+            newNumberReservation.setYear(yearStr);
+            newNumberReservation.setMonth(monthStr);
+
+            save(newNumberReservation);
+        }
+        return newInvoiceCode;
+    }
+}

--- a/jeecg-module-system/jeecg-system-biz/src/main/java/org/jeecg/modules/business/service/impl/ShippingInvoiceServiceImpl.java
+++ b/jeecg-module-system/jeecg-system-biz/src/main/java/org/jeecg/modules/business/service/impl/ShippingInvoiceServiceImpl.java
@@ -246,4 +246,14 @@ public class ShippingInvoiceServiceImpl extends ServiceImpl<ShippingInvoiceMappe
     public void cancelInvoice(String invoiceId) {
         shippingInvoiceMapper.cancelInvoice(invoiceId);
     }
+
+    @Override
+    public String findLatestInvoiceNumber() {
+        return shippingInvoiceMapper.findLatestInvoiceNumber();
+    }
+
+    @Override
+    public String findLatestCompleteInvoiceNumber() {
+        return shippingInvoiceMapper.findLatestCompleteInvoiceNumber();
+    }
 }

--- a/jeecg-module-system/jeecg-system-biz/src/main/java/org/jeecg/modules/business/service/impl/purchase/PurchaseOrderServiceImpl.java
+++ b/jeecg-module-system/jeecg-system-biz/src/main/java/org/jeecg/modules/business/service/impl/purchase/PurchaseOrderServiceImpl.java
@@ -7,7 +7,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.shiro.SecurityUtils;
 import org.jeecg.common.system.vo.LoginUser;
 import org.jeecg.modules.business.controller.UserException;
-import org.jeecg.modules.business.domain.codeGeneration.PurchaseInvoiceCodeRule;
 import org.jeecg.modules.business.domain.purchase.invoice.PurchaseInvoice;
 import org.jeecg.modules.business.domain.purchase.invoice.PurchaseInvoiceEntry;
 import org.jeecg.modules.business.entity.*;
@@ -34,6 +33,8 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.*;
 import java.util.stream.Collectors;
+
+import static org.jeecg.modules.business.entity.Invoice.InvoiceType.COMPLETE;
 
 /**
  * @Description: 商品采购订单
@@ -62,6 +63,8 @@ public class PurchaseOrderServiceImpl extends ServiceImpl<PurchaseOrderMapper, P
     private ISkuService skuService;
     @Autowired
     private ICurrencyService currencyService;
+    @Autowired
+    private IInvoiceNumberReservationService invoiceNumberReservationService;
 
     /**
      * Directory where payment documents are put
@@ -233,8 +236,7 @@ public class PurchaseOrderServiceImpl extends ServiceImpl<PurchaseOrderMapper, P
 
         String purchaseID = UUID.randomUUID().toString();
 
-        String lastInvoiceNumber = purchaseOrderMapper.lastInvoiceNumber();
-        String invoiceNumber = new PurchaseInvoiceCodeRule().next(lastInvoiceNumber);
+        String invoiceNumber = invoiceNumberReservationService.getLatestInvoiceNumberByType(COMPLETE.getType());
         // 1. save purchase itself
         purchaseOrderMapper.addPurchase(
                 purchaseID,
@@ -321,8 +323,7 @@ public class PurchaseOrderServiceImpl extends ServiceImpl<PurchaseOrderMapper, P
 
         String purchaseID = UUID.randomUUID().toString();
 
-        String lastInvoiceNumber = purchaseOrderMapper.lastInvoiceNumber();
-        String invoiceNumber = new PurchaseInvoiceCodeRule().next(lastInvoiceNumber);
+        String invoiceNumber = invoiceNumberReservationService.getLatestInvoiceNumberByType(COMPLETE.getType());
         // 1. save purchase itself
         purchaseOrderMapper.addPurchase(
                 purchaseID,


### PR DESCRIPTION
feat : Invoice Number Reservation

When asking for an invoice number while creating an invoice, will `create/edit` an `invoice_number_reservation` entry with the current date and new number for corresponding type. 
So **only 1** entry per type is saved at all time, corresponding to the latest asked invoice number.
This works thanks to :
```java
@Transactional(propagation = Propagation.REQUIRES_NEW)
```
allowing immediate commit regardless of transaction state of caller